### PR TITLE
Fix credit card industry number validation to check the first number

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,8 @@ CHANGES
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix credit card industry validation to check the first number, not
+  the second.
 
 
 1.0.0 (2013-03-01)

--- a/src/z3c/schema/payments/README.txt
+++ b/src/z3c/schema/payments/README.txt
@@ -66,7 +66,7 @@ valid card must start with one of these numbers:
     NotValidISO7812CreditCard: 2222222222222224
 
     >>> cc.validate(u'3333333333333331')
-    >>> cc.validate(u'4444444444444448')
+    >>> cc.validate(u'4111111111111111')
     >>> cc.validate(u'5555555555555557')
     >>> cc.validate(u'3333333333333331')
     >>> cc.validate(u'6666666666666664')
@@ -129,4 +129,3 @@ number registered with a financial institution:
     Traceback (most recent call last):
     ...
     NotValidISO7812CreditCard: 4444444444444449
-

--- a/src/z3c/schema/payments/field.py
+++ b/src/z3c/schema/payments/field.py
@@ -24,7 +24,7 @@ def isValidCreditCard(cardNum):
        is low and pre-validating is fast"""
 
     financialIndustries = ['3','4','5','6']
-    if cardNum[1] not in financialIndustries:
+    if cardNum[0] not in financialIndustries:
         return False
 
     total = pos = 0


### PR DESCRIPTION
Fix credit card industry validation to check the first number, not the second, and adjust the test case to show this.