### PR TITLE
Fix generating documentation.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,10 +7,14 @@ on:
   pull_request:
   schedule:
     - cron: '0 12 * * 0'  # run once a week on Sunday
+  # Allow to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   build:
     strategy:
+      # We want do see all failures:
+      fail-fast: false
       matrix:
         config:
         # [Python version, tox env]

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "ff37be82c6e4d7c4f0f96f4937f2d14d1aadae67"
+commit-id = "f8468b0bc5c92479b3043372d89cf5852176015d"
 
 [python]
 with-appveyor = false
@@ -29,4 +29,6 @@ ignore-bad-ideas = [
 additional-rules = [
     "recursive-include src *.po",
     "recursive-include src *.pot",
+    "recursive-include src *.txt",
+    "recursive-include src *.zcml",
     ]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,16 +5,13 @@ include *.txt
 include buildout.cfg
 include tox.ini
 
-recursive-include docs *.bat
 recursive-include docs *.py
 recursive-include docs *.rst
 recursive-include docs *.txt
 recursive-include docs Makefile
 
-recursive-include src *.pt
 recursive-include src *.py
-recursive-include src *.rst
-recursive-include src *.txt
-recursive-include src *.zcml
 recursive-include src *.po
 recursive-include src *.pot
+recursive-include src *.txt
+recursive-include src *.zcml

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,8 @@ commands =
 [testenv:docs]
 basepython = python3
 skip_install = false
-deps =
+# Until repoze.sphinx.autointerface supports Sphinx 4.x we cannot use it:
+deps = Sphinx < 4
 extras =
     docs
 commands_pre =


### PR DESCRIPTION
Use `Sphinx < 4` to prevent problems with `repoze.sphinx.autointerface`.